### PR TITLE
Update Rule 1.2 for Concerns of Age.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Examples of moderation expectations:
 
 1.2.c - Any form of pedophilia apologism, which includes encouraging, supporting or empasising with anyone who has commited such acts may result in removal from the community with no notice. This rule extends to user profiles including status', profile pictures, bio's and other ways a user may express themselves.
 
-Note - A large amount of bans made for this rule before the inclusion of 1.2.c on the 17th March 2025 are likely not 1.2.c applicable and we ask that members do not assume such.
+Please do note that a large amount of bans made for this rule before the inclusion of 1.2.c on the 17th March 2025 are likely not 1.2.c applicable and we ask that members do not assume such.
 
 ### 1.3. Mutual Respect
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,13 @@ Examples of moderation expectations:
 
 ### 1.2. Concerns of Age
 
-Discord's minimum age for usage is 13. Therefore, we should presume that all users here are of this minimum age. Do not automatically assume that any user is 18 or older. Furthermore, this server should not be used as a dating platform, nor should any communication involve sexually suggestive language or undertones.
+1.2.a - Discord's minimum age for usage is 13. Therefore, we should presume that all users here are of this minimum age as per the Terms of Service you agree to when joining the Discord platform. Failure to comply will result in your immediate removal from the community due to concerns regarding age and safeguarding.
+
+1.2.b - Do not automatically assume that any user is 18 or older. Furthermore, this server should not be used as a dating platform, nor should any communication involve sexually suggestive language or undertones.
+
+1.2.c - Any form of pedophilia apologism, which includes encouraging, supporting or empasising with anyone who has commited such acts may result in removal from the community with no notice. This rule extends to user profiles including status', profile pictures, bio's and other ways a user may express themselves.
+
+Note - A large amount of bans made for this rule before the inclusion of 1.2.c on the 17th March 2025 are likely not 1.2.c applicable and we ask that members do not assume such.
 
 ### 1.3. Mutual Respect
 


### PR DESCRIPTION
Updated Rule 1.2 to account for pedophilia apologism, clarified actions taken against under 13 users, and make using ATL as a dating platform a separate rule.

Please refer to 1.2.a, 1.2.b, 1.2.c for more information.

Added a note to make it clear that the vast majority of bans for the old 1.2 do not account for 1.2.c