### PR TITLE
Fix typos and wording in 3.5.b

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,11 +369,11 @@ Additionally, Moderators reserve the right to:
 Administrators outline and uphold our standards.
 
 * **Dispute regarding conduct**
-  * Administrators are permitted to resolve dispute regarding the code of conduct by using Context, Perspective and Interpretation to ensure order.
-* **Internel and Externel**
-  * Administrators are permitted to Investigate internel and externel interest and speak for the organization.
+  * Administrators are permitted to resolve dispute regarding the Code of Conduct by using Context, Perspective and Interpretation to ensure order.
+* **Internal and External**
+  * Administrators are permitted to investigate internal and external interests and speak for the organization.
 * **Termination**
-  * Administrators are permitted to Terminate Members displaying any description of unsuitable behavior, unrelated to compliance with conduct.
+  * Administrators are permitted to Terminate Members displaying any description of unsuitable behavior, unrelated to compliance with the Code of Cconduct.
 <!-- TODO: Clarification is further needed on this topic. -->
 
 ### 3.6. Punishment Evasion

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ Administrators outline and uphold our standards.
 * **Internal and External**
   * Administrators are permitted to investigate internal and external interests and speak for the organization.
 * **Termination**
-  * Administrators are permitted to Terminate Members displaying any description of unsuitable behavior, unrelated to compliance with the Code of Cconduct.
+  * Administrators are permitted to terminate Members displaying any description of unsuitable behavior, unrelated to compliance with the Code of Conduct.
 <!-- TODO: Clarification is further needed on this topic. -->
 
 ### 3.6. Punishment Evasion

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Additionally, Moderators reserve the right to:
 Administrators outline and uphold our standards.
 
 * **Dispute regarding conduct**
-  * Administrators are permitted to resolve dispute regarding the Code of Conduct by using Context, Perspective and Interpretation to ensure order.
+  * Administrators are permitted to resolve disputes regarding the Code of Conduct by using context, perspective and interpretation to ensure order.
 * **Internal and External**
   * Administrators are permitted to investigate internal and external interests and speak for the organization.
 * **Termination**


### PR DESCRIPTION
Capitalized Code of Conduct, fixed spelling of Internal and external, also clarified a tiny bit on what administrators are allowed to do.