### PR TITLE
Updated 1.1 (typo and clarification.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ Your presence in this server implies accepting Discord’s Community Guidelines 
 
 ### 1.1. SFW Policy
 
-This is a Safe for Work (SFW) environment, which strictly prohibits Not Safe for Work (NSFW) content and discussions. NSFW usually refers to sexually explicit content, however the definition is expanding to include a broader range of sensitive topics over time. Although Discord allows servers to create designated NSFW channels, it's worth noting that this platform does not offer such channels.
+This is a Safe for Work (SFW) environment, which strictly prohibits Not Safe for Work (NSFW) content and discussions. Although Discord allows servers to create designated NSFW channels, it's worth noting that this platform does not offer such channels.
 
 1.1.a - Do not share sexually explicit content in messages or media.
 
 1.1.b - Do not portray sexually explicit content in Member avatars, custom statuses, “About Me” texts, banners, emotes, stickers, or any other Member profile feature/expression.
 
-1.1.c - Do not share media depicting gore, excessive violence, or animal abuse. Excessive violence, for the puposes of this CoC, is defined as content that includes but is not limited to:
+1.1.c - Do not share media depicting gore, excessive violence, or animal abuse. Excessive violence, for the purposes of this CoC, is defined as content that includes but is not limited to:
 
 * Real-life imagery, including gore, severe injury or death.
-* Violent ficitional content.
+* Violent fictional content.
 * Any media that is intended to shock, disturb or incite harm.
 
 1.1.d - Do not share content that glorifies, promotes, or normalizes suicide or other acts of self-harm. Self-harm acts or threats used as a form of emotional manipulation or coercion are also prohibited.


### PR DESCRIPTION
Updated typos on Line 84 and in 1.1.c - also removed vague definition - definition is suited appropriately now.

## Summary by Sourcery

Update the README’s Safe-for-Work policy section to remove a vague NSFW expansion note and correct typos in clause 1.1.c.

Documentation:
- Clarify 1.1 SFW policy by removing the outdated NSFW definition expansion remark
- Fix typos in clause 1.1.c (‘purposes’ and ‘fictional’)