### PR TITLE
fix(action): fix a syntax error

### DIFF
--- a/.github/workflows/generate-readme.yml
+++ b/.github/workflows/generate-readme.yml
@@ -43,3 +43,4 @@ jobs:
           else
             git commit -m "chore(gencoc): update the code of conduct" -m "[skip ci]"
             git push --force-with-lease origin main
+          fi


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add missing 'fi' statement to fix syntax error in the generate-readme workflow